### PR TITLE
Fix Template Literal String Conversion for ECMAScript Compliance

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -810,6 +810,14 @@ class CodeGenerator extends Icode {
                 stackChange(-1);
                 break;
 
+            case Token.STRING_CONCAT:
+                visitExpression(child, 0);
+                child = child.getNext();
+                visitExpression(child, 0);
+                addToken(type);
+                stackChange(-1);
+                break;
+
             case Token.POS:
             case Token.NEG:
             case Token.NOT:

--- a/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IRFactory.java
@@ -1050,13 +1050,13 @@ public final class IRFactory {
         Node pn = Node.newString("");
         for (AstNode elem : elems) {
             if (elem.getType() != Token.TEMPLATE_CHARS) {
-                pn = createBinary(Token.ADD, pn, transform(elem));
+                pn = createBinary(Token.STRING_CONCAT, pn, transform(elem));
             } else {
                 TemplateCharacters chars = (TemplateCharacters) elem;
                 // skip empty parts, e.g. `xx${expr}xx` where xx denotes the empty string
                 String value = chars.getValue();
                 if (value.length() > 0) {
-                    pn = createBinary(Token.ADD, pn, Node.newString(value));
+                    pn = createBinary(Token.STRING_CONCAT, pn, Node.newString(value));
                 }
             }
         }
@@ -1104,6 +1104,7 @@ public final class IRFactory {
             body.addChildToBack(transform((AstNode) kid));
         }
         node.removeChildren();
+
         Node children = body.getFirstChild();
         if (children != null) {
             node.addChildrenToBack(children);

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -1415,6 +1415,7 @@ public final class Interpreter extends Icode implements Evaluator {
         instructionObjs[base + Token.NOT] = new DoNot();
         instructionObjs[base + Token.BINDNAME] = new DoBindName();
         instructionObjs[base + Token.STRICT_SETNAME] = new DoSetName();
+        instructionObjs[base + Token.STRING_CONCAT] = new DoStringConcat();
         instructionObjs[base + Token.SETNAME] = new DoSetName();
         instructionObjs[base + Icode_SETCONST] = new DoSetConst();
         instructionObjs[base + Token.DELPROP] = new DoDelName();
@@ -2744,6 +2745,31 @@ public final class Interpreter extends Icode implements Evaluator {
                             ? ScriptRuntime.setName(lhs, rhs, cx, frame.scope, state.stringReg)
                             : ScriptRuntime.strictSetName(
                                     lhs, rhs, cx, frame.scope, state.stringReg);
+            --state.stackTop;
+            return null;
+        }
+    }
+
+    private static class DoStringConcat extends InstructionClass {
+        @Override
+        NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
+            final Object[] stack = frame.stack;
+            final double[] sDbl = frame.sDbl;
+
+            Object rhs = stack[state.stackTop];
+            Object lhs = stack[state.stackTop - 1];
+
+            if (rhs == DOUBLE_MARK) {
+                rhs = ScriptRuntime.wrapNumber(sDbl[state.stackTop]);
+            }
+            if (lhs == DOUBLE_MARK) {
+                lhs = ScriptRuntime.wrapNumber(sDbl[state.stackTop - 1]);
+            }
+
+            String rhsString = ScriptRuntime.toString(rhs);
+            String lhsString = ScriptRuntime.toString(lhs);
+
+            stack[state.stackTop - 1] = lhsString.concat(rhsString);
             --state.stackTop;
             return null;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -2753,23 +2753,20 @@ public final class Interpreter extends Icode implements Evaluator {
     private static class DoStringConcat extends InstructionClass {
         @Override
         NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
-            final Object[] stack = frame.stack;
-            final double[] sDbl = frame.sDbl;
-
-            Object rhs = stack[state.stackTop];
-            Object lhs = stack[state.stackTop - 1];
+            Object rhs = frame.stack[state.stackTop];
+            Object lhs = frame.stack[state.stackTop - 1];
 
             if (rhs == DOUBLE_MARK) {
-                rhs = ScriptRuntime.wrapNumber(sDbl[state.stackTop]);
+                rhs = ScriptRuntime.wrapNumber(frame.sDbl[state.stackTop]);
             }
             if (lhs == DOUBLE_MARK) {
-                lhs = ScriptRuntime.wrapNumber(sDbl[state.stackTop - 1]);
+                lhs = ScriptRuntime.wrapNumber(frame.sDbl[state.stackTop - 1]);
             }
 
             String rhsString = ScriptRuntime.toString(rhs);
             String lhsString = ScriptRuntime.toString(lhs);
 
-            stack[state.stackTop - 1] = lhsString.concat(rhsString);
+            frame.stack[state.stackTop - 1] = new ConsString(lhsString, rhsString);
             --state.stackTop;
             return null;
         }
@@ -2792,14 +2789,12 @@ public final class Interpreter extends Icode implements Evaluator {
     private static class DoDelName extends InstructionClass {
         @Override
         NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
-            final Object[] stack = frame.stack;
-            final double[] sDbl = frame.sDbl;
-            Object rhs = stack[state.stackTop];
-            if (rhs == DOUBLE_MARK) rhs = ScriptRuntime.wrapNumber(sDbl[state.stackTop]);
+            Object rhs = frame.stack[state.stackTop];
+            if (rhs == DOUBLE_MARK) rhs = ScriptRuntime.wrapNumber(frame.sDbl[state.stackTop]);
             --state.stackTop;
-            Object lhs = stack[state.stackTop];
-            if (lhs == DOUBLE_MARK) lhs = ScriptRuntime.wrapNumber(sDbl[state.stackTop]);
-            stack[state.stackTop] =
+            Object lhs = frame.stack[state.stackTop];
+            if (lhs == DOUBLE_MARK) lhs = ScriptRuntime.wrapNumber(frame.sDbl[state.stackTop]);
+            frame.stack[state.stackTop] =
                     ScriptRuntime.delete(lhs, rhs, cx, frame.scope, op == Icode_DELNAME);
             return null;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/Token.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Token.java
@@ -120,7 +120,8 @@ public class Token {
             YIELD = REF_SPECIAL + 1, // JS 1.7 yield pseudo keyword
             SUPER = YIELD + 1, // ES6 super keyword
             STRICT_SETNAME = SUPER + 1,
-            EXP = STRICT_SETNAME + 1, // Exponentiation Operator
+            STRING_CONCAT = STRICT_SETNAME + 1,
+            EXP = STRING_CONCAT + 1, // Exponentiation Operator
 
             // For XML support:
             DEFAULTNAMESPACE = EXP + 1, // default xml namespace =
@@ -634,6 +635,8 @@ public class Token {
                 return "BIGINT";
             case TEMPLATE_LITERAL:
                 return "TEMPLATE_LITERAL";
+            case STRING_CONCAT:
+                return "STRING_CONCAT";
             case TEMPLATE_CHARS:
                 return "TEMPLATE_CHARS";
             case TEMPLATE_LITERAL_SUBST:

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -1343,6 +1343,13 @@ class BodyCodegen {
                 }
                 break;
 
+            case Token.STRING_CONCAT:
+                generateExpression(child, node);
+                generateExpression(child.getNext(), node);
+                addOptRuntimeInvoke(
+                        "concat", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+                break;
+
             case Token.SUB:
             case Token.MUL:
             case Token.DIV:

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -6,6 +6,7 @@ package org.mozilla.javascript.optimizer;
 
 import org.mozilla.javascript.ArrowFunction;
 import org.mozilla.javascript.Callable;
+import org.mozilla.javascript.ConsString;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ES6Generator;
@@ -135,7 +136,7 @@ public final class OptRuntime extends ScriptRuntime {
         String rhsString = ScriptRuntime.toString(rhs);
         String lhsString = ScriptRuntime.toString(lhs);
 
-        return lhsString.concat(rhsString);
+        return new ConsString(lhsString, rhsString);
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -131,6 +131,13 @@ public final class OptRuntime extends ScriptRuntime {
         return ScriptRuntime.add(val1, val2, cx);
     }
 
+    public static Object concat(Object lhs, Object rhs) {
+        String rhsString = ScriptRuntime.toString(rhs);
+        String lhsString = ScriptRuntime.toString(lhs);
+
+        return lhsString.concat(rhsString);
+    }
+
     /**
      * @deprecated Use {@link #elemIncrDecr(Object, double, Context, Scriptable, int)} instead
      */

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -679,7 +679,6 @@ built-ins/BigInt 7/75 (9.33%)
     asUintN/bigint-tobigint-errors.js
     asUintN/bits-toindex-errors.js
     asUintN/bits-toindex-wrapped-values.js
-    wrapper-object-ordinary-toprimitive.js
 
 built-ins/Boolean 1/51 (1.96%)
     proto-from-ctor-realm.js
@@ -2080,7 +2079,6 @@ built-ins/Symbol 19/94 (20.21%)
     matchAll/cross-realm.js
     match/cross-realm.js
     prototype/Symbol.toPrimitive/redefined-symbol-wrapper-ordinary-toprimitive.js
-    prototype/Symbol.toPrimitive/removed-symbol-wrapper-ordinary-toprimitive.js
     replace/cross-realm.js
     search/cross-realm.js
     species/cross-realm.js


### PR DESCRIPTION
## Summary
This commit addresses ECMAScript specification compliance issues with template literal string conversion by introducing a dedicated `STRING_CONCAT` token and operation that properly converts objects to strings using `toString()` semantics instead of the default `ToPrimitive` behavior.

## Problem
Template literals like `${Object(1n)}` were incorrectly using the default `ToPrimitive` conversion (which calls `valueOf()` first) instead of string conversion semantics (which calls `toString()` first). This caused Test262 compliance failures where custom `toString()` methods on BigInt and Symbol wrapper objects were not being invoked correctly.

**Before**: Template literals were transformed into regular `ADD` operations, causing `${Object(1n)}` to return `"1"` instead of the expected custom `toString()` result.

**After**: Template literals use dedicated `STRING_CONCAT` operations that properly call `ScriptRuntime.toString()`, ensuring ECMAScript compliance.

## Changes Made

1. **New Token Type**: Added `Token.STRING_CONCAT` to distinguish template literal string concatenation from arithmetic addition operations.

2. **IRFactory Enhancement**: Modified `transformTemplateLiteral()` to use `STRING_CONCAT` instead of `ADD` tokens, ensuring template literal substitutions follow string conversion semantics.

3. **Interpreter Support**: Implemented `DoStringConcat` instruction class that directly converts operands to strings using `ScriptRuntime.toString()` before concatenation.

4. **Optimizer Support**: Added `STRING_CONCAT` handling in `BodyCodegen` and `OptRuntime.concat()` method for optimized execution paths.

5. **Test Improvements**: Removed 2 failing Test262 tests from the exclusion list:
   - `built-ins/BigInt/wrapper-object-ordinary-toprimitive.js`
   - `built-ins/Symbol/prototype/Symbol.toPrimitive/removed-symbol-wrapper-ordinary-toprimitive.js`

## Technical Details
- **Root Cause**: Template literals were incorrectly sharing the same code path as arithmetic addition, causing wrong `ToPrimitive` hint usage
- **Solution**: Separate template literal string concatenation from arithmetic operations at the token level
- **Performance**: Direct string conversion eliminates unnecessary `ToPrimitive` calls and type checking overhead
- **Compliance**: Ensures template literals follow ECMAScript specification for string conversion semantics

## Impact
- ✅ Resolves #1406
- ✅ Fixes ECMAScript compliance for template literal string conversion
- ✅ Improves Test262 conformance (2 additional tests now pass)
- ✅ Maintains backward compatibility for existing code
- ✅ Optimizes template literal performance by avoiding unnecessary type conversions

This change brings Rhino's template literal implementation into full compliance with the ECMAScript specification while maintaining performance and backward compatibility.